### PR TITLE
Fix joker selection

### DIFF
--- a/frontend/assets/js/values-and-share.js
+++ b/frontend/assets/js/values-and-share.js
@@ -9,7 +9,7 @@ function toggle(e) {
     }
     e.classList.contains("no-deselect") ? null : e.classList.toggle("selected")
     if (e.classList.contains("selected")) {
-        if (currentGameSelectedValueIds.indexOf(e.id) <= 0) { //add if not added
+        if (currentGameSelectedValueIds.indexOf(e.id) < 0) { //add if not added
             currentGameSelectedValueIds.push(e.id);
         }
     } else {


### PR DESCRIPTION
If the joker was selected first, it'd be re-added to the array of selected value IDs due to an off-by-one bug.

Fixes #2.